### PR TITLE
Add support for round icons.

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2735,7 +2735,7 @@
     <string name="config_demoModeLauncherComponent">com.android.retaildemo/.DemoPlayer</string>
 
     <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
-    <bool name="config_useRoundIcon">false</bool>
+    <bool name="config_useRoundIcon">true</bool>
 
     <!-- Flag indicating whether the assist disclosure can be disabled using
          ASSIST_DISCLOSURE_ENABLED. -->


### PR DESCRIPTION
Lineage is based on keeping aosp look with awesome features, so i propose, we should enable round icons to keep up with the aosp looks.