### PR TITLE
Update strings.xml

### DIFF
--- a/packages/SystemUI/res/values-tr/strings.xml
+++ b/packages/SystemUI/res/values-tr/strings.xml
@@ -345,7 +345,7 @@
     <string name="recents_accessibility_split_screen_right" msgid="275069779299592867">"Ekranı sağa doğru böl"</string>
   <string-array name="recents_blacklist_array">
   </string-array>
-    <string name="expanded_header_battery_charged" msgid="5945855970267657951">"Ödeme alındı"</string>
+    <string name="expanded_header_battery_charged" msgid="5945855970267657951">"Şarj oldu"</string>
     <string name="expanded_header_battery_charging" msgid="205623198487189724">"Şarj oluyor"</string>
     <string name="expanded_header_battery_charging_with_time" msgid="457559884275395376">"Tam şarj olmasına <xliff:g id="CHARGING_TIME">%s</xliff:g> kaldı"</string>
     <string name="expanded_header_battery_not_charging" msgid="4798147152367049732">"Şarj olmuyor"</string>


### PR DESCRIPTION
Hi @mikeNG 

I'm sorry to bother you.

There is a huge translation mistake here. and this string on the crowdin is not available.

When the device is 100% charged, the "Charged" string on the lock screen is translated into Turkish; "Ödeme alındı", English equivalent; "Payment received".

So when the device is fully charged, it displays "Payment received" in English on the screen.

Please help me fix this