### PR TITLE
 Add a minimum time between power button presses to trigger the camera

### DIFF
--- a/services/core/java/com/android/server/GestureLauncherService.java
+++ b/services/core/java/com/android/server/GestureLauncherService.java
@@ -60,6 +60,12 @@ public class GestureLauncherService extends SystemService {
     private static final boolean DBG_CAMERA_LIFT = false;
     private static final String TAG = "GestureLauncherService";
 
+     /**
+     * Minimum time in milliseconds between power button presses so it will be considered
+     * as a camera launch. To avoid false triggers.
+     */
+    @VisibleForTesting static final long CAMERA_POWER_DOUBLE_TAP_MIN_TIME_MS = 30;
+    
     /**
      * Time in milliseconds in which the power button must be pressed twice so it will be considered
      * as a camera launch.
@@ -362,6 +368,7 @@ public class GestureLauncherService extends SystemService {
         synchronized (this) {
             powerTapInterval = event.getEventTime() - mLastPowerDown;
             if (mCameraDoubleTapPowerEnabled
+                    && powerTapInterval > CAMERA_POWER_DOUBLE_TAP_MIN_TIME_MS
                     && powerTapInterval < CAMERA_POWER_DOUBLE_TAP_MAX_TIME_MS) {
                 launched = true;
                 intercept = interactive;


### PR DESCRIPTION
I frequently trigger the camera double tap shortcut unintentionally when pressing the power button once. This code adds a minimum interval between presses to hopefully avoid some of these false triggers.
In my testing I've found that false triggers are generally around 15-25ms, and real triggers are closer to 200ms, so a minimum of 30ms seems appropriate.