### PR TITLE
Important bug fix-2

### DIFF
--- a/packages/SystemUI/res-keyguard/values-tr/strings.xml
+++ b/packages/SystemUI/res-keyguard/values-tr/strings.xml
@@ -33,7 +33,7 @@
     <string name="keyguard_enter_your_password" msgid="5761514484663983731">"Şifrenizi girin"</string>
     <string name="keyguard_password_wrong_pin_code" msgid="6535018036285012028">"Yanlış PIN kodu."</string>
     <string name="keyguard_sim_error_message_short" msgid="592109500618448312">"Geçersiz Kart."</string>
-    <string name="keyguard_charged" msgid="2222329688813033109">"Ödeme alındı"</string>
+    <string name="keyguard_charged" msgid="2222329688813033109">"Şarj oldu"</string>
     <string name="keyguard_plugged_in" msgid="3161102098900158923">"<xliff:g id="PERCENTAGE">%s</xliff:g> • Şarj oluyor"</string>
     <string name="keyguard_plugged_in_charging_fast" msgid="3684592786276709342">"<xliff:g id="PERCENTAGE">%s</xliff:g> • Hızlı şarj oluyor"</string>
     <string name="keyguard_plugged_in_charging_slowly" msgid="509533586841478405">"<xliff:g id="PERCENTAGE">%s</xliff:g> • Yavaş şarj oluyor"</string>


### PR DESCRIPTION
Hi @mikeNG 

There is a very large translation error.

And this needs to be changed through the file.

I know you didn't agree to merge requests through Github.

But it must be corrected. When the device is 100% charged, the lock screen shows "Ödeme alındı" (English: Payment received) in Turkish.

The right one needs to be "Şarj oldu" (English: Charged).

It's not so nice to write "Payment received" on the phone screen.

Merge please

Thanks for your understanding

Mevlüt