### PR TITLE
Important bug fix

### DIFF
--- a/packages/SystemUI/res/values-tr/strings.xml
+++ b/packages/SystemUI/res/values-tr/strings.xml
@@ -370,7 +370,7 @@
     <string name="recents_accessibility_split_screen_left" msgid="8987144699630620019">"Ekranı sola doğru böl"</string>
     <string name="recents_accessibility_split_screen_right" msgid="275069779299592867">"Ekranı sağa doğru böl"</string>
     <string name="quick_step_accessibility_toggle_overview" msgid="7171470775439860480">"Genel bakışı aç/kapat"</string>
-    <string name="expanded_header_battery_charged" msgid="5945855970267657951">"Ödeme alındı"</string>
+    <string name="expanded_header_battery_charged" msgid="5945855970267657951">"Şarj oldu"</string>
     <string name="expanded_header_battery_charging" msgid="205623198487189724">"Şarj oluyor"</string>
     <string name="expanded_header_battery_charging_with_time" msgid="457559884275395376">"Tam şarj olmasına <xliff:g id="CHARGING_TIME">%s</xliff:g> kaldı"</string>
     <string name="expanded_header_battery_not_charging" msgid="4798147152367049732">"Şarj olmuyor"</string>


### PR DESCRIPTION
Hi @mikeNG 

There is a very large translation error.

And this needs to be changed through the file.

I know you didn't agree to merge requests through Github.

But it must be corrected. When the device is 100% charged, the lock screen shows "Ödeme alındı" (English: Payment received) in Turkish.

The right one needs to be "Şarj oldu" (English: Charged).

It's not so nice to write "Payment received" on the phone screen.

Merge please

Thanks for your understanding

Mevlüt