### PR TITLE
Use servers from the NTP Pool Project

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2030,7 +2030,7 @@
     <bool name="config_actionMenuItemAllCaps">true</bool>
 
     <!-- Remote server that can provide NTP responses. -->
-    <string translatable="false" name="config_ntpServer">time.android.com</string>
+    <string translatable="false" name="config_ntpServer">0.pool.ntp.org</string>
     <!-- Normal polling frequency in milliseconds -->
     <integer name="config_ntpPollingInterval">86400000</integer>
     <!-- Try-again polling interval in milliseconds, in case the network request failed -->


### PR DESCRIPTION
Hi,

Do not use a google server because it analyzes too your requests. 
Let's use use pool.ntp.org as in Ubuntu, Debian...
See http://www.pool.ntp.org/join.html and https://bugs.launchpad.net/ubuntu/+source/ntp/+bug/104525 for more information.