### PR TITLE
HeadsUpStatusBarView: account for rounded corner

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/HeadsUpStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/HeadsUpStatusBarView.java
@@ -82,7 +82,9 @@ public class HeadsUpStatusBarView extends AlphaOptimizedLinearLayout {
         Resources res = getResources();
         mAbsoluteStartPadding = res.getDimensionPixelSize(R.dimen.notification_side_paddings)
             + res.getDimensionPixelSize(
-                    com.android.internal.R.dimen.notification_content_margin_start);
+	        	com.android.internal.R.dimen.notification_content_margin_start)
+            + res.getDimensionPixelSize(
+	                R.dimen.rounded_corner_content_padding);
         mEndMargin = res.getDimensionPixelSize(
                 com.android.internal.R.dimen.notification_content_margin_end);
         setPaddingRelative(mAbsoluteStartPadding, 0, mEndMargin, 0);


### PR DESCRIPTION
On devices with big value "rounded_corner_content_padding" heads up status bar notification icons are not displayed correctly — the icon gets cropped. This adds more padding to the status bar heads up display, depending on the value of "rounded_corner_content_padding".