### PR TITLE
Added missing permission check to isPackageDeviceAdminOnAnyUser.

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -1595,8 +1595,13 @@ public class NotificationManagerService extends SystemService {
         @Override
         public boolean areNotificationsEnabledForPackage(String pkg, int uid) {
             checkCallerIsSystemOrSameApp(pkg);
-            return (mAppOps.checkOpNoThrow(AppOpsManager.OP_POST_NOTIFICATION, uid, pkg)
-                    == AppOpsManager.MODE_ALLOWED) && !isPackageSuspendedForUser(pkg, uid);
+            if (UserHandle.getCallingUserId() != UserHandle.getUserId(uid)) {
+                getContext().enforceCallingPermission(
+                        android.Manifest.permission.INTERACT_ACROSS_USERS,
+                        "canNotifyAsPackage for uid " + uid);
+            }
+
+            return mRankingHelper.getImportance(pkg, uid) != IMPORTANCE_NONE;
         }
 
         @Override

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -15871,17 +15871,6 @@ public class PackageManagerService extends IPackageManager.Stub {
 
     @Override
     public boolean isPackageDeviceAdminOnAnyUser(String packageName) {
-        final int callingUid = Binder.getCallingUid();
-        if (checkUidPermission(android.Manifest.permission.MANAGE_USERS, callingUid)
-                != PERMISSION_GRANTED) {
-            EventLog.writeEvent(0x534e4554, "128599183", -1, "");
-            throw new SecurityException(android.Manifest.permission.MANAGE_USERS
-                    + " permission is required to call this API");
-        }
-        if (getInstantAppPackageName(callingUid) != null
-                && !isCallerSameApp(packageName, callingUid)) {
-            return false;
-        }
         return isPackageDeviceAdmin(packageName, UserHandle.USER_ALL);
     }
 

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -15871,6 +15871,17 @@ public class PackageManagerService extends IPackageManager.Stub {
 
     @Override
     public boolean isPackageDeviceAdminOnAnyUser(String packageName) {
+        final int callingUid = Binder.getCallingUid();
+        if (checkUidPermission(android.Manifest.permission.MANAGE_USERS, callingUid)
+                != PERMISSION_GRANTED) {
+            EventLog.writeEvent(0x534e4554, "128599183", -1, "");
+            throw new SecurityException(android.Manifest.permission.MANAGE_USERS
+                    + " permission is required to call this API");
+        }
+        if (getInstantAppPackageName(callingUid) != null
+                && !isCallerSameApp(packageName, callingUid)) {
+            return false;
+        }
         return isPackageDeviceAdmin(packageName, UserHandle.USER_ALL);
     }
 

--- a/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
+++ b/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
@@ -3156,6 +3156,9 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
 
     @Override
     public boolean isSeparateProfileChallengeAllowed(int userHandle) {
+        if (!isCallerWithSystemUid()) {
+            throw new SecurityException("Caller must be system");
+        }
         ComponentName profileOwner = getProfileOwner(userHandle);
         // Profile challenge is supported on N or newer release.
         return profileOwner != null &&

--- a/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
+++ b/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
@@ -7145,6 +7145,7 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
         if (!mHasFeature) {
             return null;
         }
+        enforceManageUsers();
         synchronized (this) {
             List<String> result = null;
             // If we have multiple profiles we return the intersection of the


### PR DESCRIPTION
Added a check for the MANAGE_USERS permission to
PackageManagerService#isPackageDeviceAdminOnAnyUser.

To test that the method is still usable:
1) Enable virtual storage via: adb shell sm set-virtual-disk true
2) Follow instructions by clicking on notification to set up virtual storage
3) Go to Settings -> Apps & notifications -> See all X apps
4) Click on any non-system app (example Instagram)
5) Tap Storage and you should see a "Change" button (if not, choose another app)
6) Tap Change and you should see Internal and Virtual storage options listed
7) The above step confirms the method is still usable by Settings

Bug: 128599183
Test: SafetyNet logging (steps listed above)
Change-Id: I989f1daf52a71f6c778ebd81baa6f1bf83e9a718
Merged-In: I36521fa43daab399e08869647326a7ac32d1e512
(cherry picked from commit 18e7dedf6c35f07daf8b7239d501737745ac7f43)