### PR TITLE
 enable boot/bootloader/radio version checks

### DIFF
--- a/core/java/android/os/Build.java
+++ b/core/java/android/os/Build.java
@@ -1102,7 +1102,6 @@ public class Build {
             }
         }
 
-        /* TODO: Figure out issue with checks failing
         if (!TextUtils.isEmpty(bootimage)) {
             if (!Objects.equals(system, bootimage)) {
                 Slog.e(TAG, "Mismatched fingerprints; system reported " + system
@@ -1119,7 +1118,7 @@ public class Build {
             }
         }
 
-        if (!TextUtils.isEmpty(requiredRadio)) {
+        if (!TextUtils.isEmpty(requiredRadio) && !TextUtils.isEmpty(currentRadio)) {
             if (!Objects.equals(currentRadio, requiredRadio)) {
                 Slog.e(TAG, "Mismatched radio version: build requires " + requiredRadio
                         + " but runtime reports " + currentRadio);


### PR DESCRIPTION
This enables the Build.isBuildConsistent checks after tweaking the radio
check to stop failing when the radio hasn't been turned on. The property
used to check the radio version (gsm.baseband.version) is only set once
the radio is turned on and initialized.

The API documentation already claims that this is done.