### PR TITLE
enable boot/bootloader/radio version checks

### DIFF
--- a/core/java/android/os/Build.java
+++ b/core/java/android/os/Build.java
@@ -1126,7 +1126,6 @@ public class Build {
                 return false;
             }
         }
-        */
 
         return true;
     }


### PR DESCRIPTION
This enables the Build.isBuildConsistent checks after tweaking the radio
check to stop failing when the radio hasn't been turned on. The property
used to check the radio version (gsm.baseband.version) is only set once
the radio is turned on and initialized.

The API documentation already claims that this is done.