### PR TITLE
Change config_WallpaperCopperPackage

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -3421,7 +3421,7 @@
     <!-- Wallpaper cropper package. Used as the default cropper if the active launcher doesn't
          handle wallpaper cropping.
     -->
-    <string name="config_wallpaperCropperPackage" translatable="false">com.android.wallpapercropper</string>
+    <string name="config_wallpaperCropperPackage" translatable="false">com.android.wallpaper</string>
 
     <!-- True if the device supports at least one form of multi-window.
          E.g. freeform, split-screen, picture-in-picture. -->


### PR DESCRIPTION
It now uses "com.android.wallpapercropper"
Change it to "com.android.wallpaper" so from gallery we will have the options to set a picture as wallpaper for "homescreen only", "lockscreen only", and "both homescreen and lockscreen".