### PR TITLE
Update missing dependency for libhwui in Android.bp

### DIFF
--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -70,6 +70,7 @@ cc_defaults {
         "libandroidfw",
         "libcrypto",
         "libsync",
+        "libbase",
     ],
     static_libs: [
         "libEGL_blobCache",


### PR DESCRIPTION
external/skia/src/gpu/gl/GrGLCaps.h uses android::base::GetBoolProperty and thus requires libbase to be linked
(w/o build process for phhgsi fails)