### PR TITLE
ActivityThread: Remove Failed to find provider info logspam

### DIFF
--- a/core/java/android/app/ActivityThread.java
+++ b/core/java/android/app/ActivityThread.java
@@ -6820,11 +6820,6 @@ public final class ActivityThread extends ClientTransactionHandler {
             throw ex.rethrowFromSystemServer();
         }
         if (holder == null) {
-            if (UserManager.get(c).isUserUnlocked(userId)) {
-                Slog.e(TAG, "Failed to find provider info for " + auth);
-            } else {
-                Slog.w(TAG, "Failed to find provider info for " + auth + " (user not unlocked)");
-            }
             return null;
         }
 


### PR DESCRIPTION
03-30 14:21:20.547  2706  2969 W ActivityThread: Failed to find provider info for com.google.android.gsf.gservices (user not unlocked)

Signed-off-by: HeroBuxx <herobuxx@conqueros.co>